### PR TITLE
feat(auth): add loading state to AuthProvider and enhance route compo…

### DIFF
--- a/react-app/.env.example
+++ b/react-app/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3000/api/v1

--- a/react-app/src/components/GuestRoute.tsx
+++ b/react-app/src/components/GuestRoute.tsx
@@ -1,3 +1,4 @@
+import { Box, CircularProgress } from "@mui/material";
 import { Navigate } from "react-router-dom";
 import { useAuth } from "../providers/AuthProvider";
 
@@ -6,7 +7,15 @@ interface GuestRouteProps {
 }
 
 const GuestRoute = ({ children }: GuestRouteProps) => {
-    const { user } = useAuth();
+    const { user, isLoading } = useAuth();
+
+    if (isLoading) {
+        return (
+            <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh">
+                <CircularProgress />
+            </Box>
+        );
+    }
 
     if (user) {
         return <Navigate to="/home" replace />;

--- a/react-app/src/components/ProtectedRoute.tsx
+++ b/react-app/src/components/ProtectedRoute.tsx
@@ -1,3 +1,4 @@
+import { Box, CircularProgress } from "@mui/material";
 import { Navigate } from "react-router-dom";
 import { useAuth } from "../providers/AuthProvider";
 
@@ -6,7 +7,15 @@ interface ProtectedRouteProps {
 }
 
 const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
-    const { user } = useAuth();
+    const { user, isLoading } = useAuth();
+
+    if (isLoading) {
+        return (
+            <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh">
+                <CircularProgress />
+            </Box>
+        );
+    }
 
     if (!user) {
         return <Navigate to="/login" replace />;

--- a/react-app/src/providers/AuthProvider.tsx
+++ b/react-app/src/providers/AuthProvider.tsx
@@ -201,7 +201,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         <AuthContext.Provider
             value={{ user, isLoading, authError, login, logout, register, updateProfile }}
         >
-            {isLoading ? <div>Loading...</div> : children}
+            {children}
         </AuthContext.Provider>
     );
 };


### PR DESCRIPTION
`ProtectedRoute` and `GuestRoute` already existed from PR #11 but had a race condition: both components checked user without accounting for isLoading. 

TL:DR, Example
1. User logs in, token is saved to localStorage, they're on /home
2. User refreshes the page (F5)
3. React remounts — AuthProvider starts checkAuth(), sets isLoading = true, user = null
4. Router renders /home → ProtectedRoute runs immediately
5. ProtectedRoute sees user === null → redirects to /login
6. 300ms later, checkAuth() finishes, user is set — but the user is already sitting on /login

On app mount, user is null while checkAuth() runs — authenticated users would briefly get redirected to /login before the session restore completed. This PR fixes that and moves the loading concern to the correct layer.

When the app loads, AuthProvider kicks off checkAuth() asynchronously — it reads the token from localStorage, decodes it, then hits GET /auth/me to fetch the user. This takes time.

  During that window, the context state is:

```
   user = null
   isLoading = true
```

  The old ProtectedRoute only checked user:

```
   const { user } = useAuth();
   if (!user) return <Navigate to="/login" replace />;
```

So the instant a protected route renders, it sees user = null and fires the **redirect** — before checkAuth() has a chance to finish.